### PR TITLE
feat: add fuji testnet + specify block/confirmation times

### DIFF
--- a/ape_avalanche/ecosystem.py
+++ b/ape_avalanche/ecosystem.py
@@ -7,6 +7,7 @@ from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (43114, 43114),
+    "fuji": (43113, 43113),
 }
 
 
@@ -26,8 +27,10 @@ def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfi
 
 
 class AvalancheConfig(PluginConfig):
-    mainnet: NetworkConfig = _create_network_config()
+    mainnet: NetworkConfig = _create_network_config(required_confirmations=1, block_time=2)
     mainnet_fork: NetworkConfig = _create_local_config()
+    fuji: NetworkConfig = _create_network_config(required_confirmations=1, block_time=2)
+    fuji_fork: NetworkConfig = _create_local_config()
     local: NetworkConfig = _create_local_config(default_provider="test")
     default_network: str = LOCAL_NETWORK_NAME
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,8 @@ EXPECTED_OUTPUT = """
 avalanche
 ├── mainnet
 │   └── geth  (default)
+├── fuji
+│   └── geth  (default)
 └── local  (default)
     └── test  (default)
 """.strip()


### PR DESCRIPTION
### What I did

Adds support for the Fuji testnet, 

fixes: APE-622

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
