### PR TITLE
feat: support for Fuji testnet of Avalanche [APE-714]

### DIFF
--- a/ape_avalanche/__init__.py
+++ b/ape_avalanche/__init__.py
@@ -21,10 +21,10 @@ def ecosystems():
 def networks():
     for network_name, network_params in NETWORKS.items():
         yield "avalanche", network_name, create_network_type(*network_params)
-        yield "avalanche", f"{network_name}-fork", NetworkAPI
 
     # NOTE: This works for development providers, as they get chain_id from themselves
     yield "avalanche", LOCAL_NETWORK_NAME, NetworkAPI
+    yield "avalanche", "mainnet-fork", NetworkAPI
 
 
 @plugins.register(plugins.ProviderPlugin)

--- a/ape_avalanche/ecosystem.py
+++ b/ape_avalanche/ecosystem.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
@@ -7,28 +5,14 @@ from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 NETWORKS = {
     # chain_id, network_id
     "mainnet": (43114, 43114),
+    "fuji": (43113, 43113),
 }
 
 
-def _create_network_config(
-    required_confirmations: int = 1, block_time: int = 1, **kwargs
-) -> NetworkConfig:
-    # Helper method to isolate `type: ignore` comments.
-    return NetworkConfig(
-        required_confirmations=required_confirmations, block_time=block_time, **kwargs
-    )  # type: ignore
-
-
-def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfig:
-    return _create_network_config(
-        required_confirmations=0, block_time=0, default_provider=default_provider
-    )
-
-
 class AvalancheConfig(PluginConfig):
-    mainnet: NetworkConfig = _create_network_config()
-    mainnet_fork: NetworkConfig = _create_local_config()
-    local: NetworkConfig = _create_local_config(default_provider="test")
+    mainnet: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=2)  # type: ignore
+    fuji: NetworkConfig = NetworkConfig(required_confirmations=1, block_time=2)  # type: ignore
+    local: NetworkConfig = NetworkConfig(default_provider="test")  # type: ignore
     default_network: str = LOCAL_NETWORK_NAME
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,8 @@ EXPECTED_OUTPUT = """
 avalanche
 ├── mainnet
 │   └── geth  (default)
+├── fuji
+│   └── geth  (default)
 └── local  (default)
     └── test  (default)
 """.strip()


### PR DESCRIPTION
**Context:** since https://github.com/ApeWorX/ape/issues/1336, `ape plugins install avalanche` PyPi points to https://github.com/ApeWorX/ape-avalanche (1) instead of https://github.com/albertocevallos/ape-avalanche (2) 

**Problem:** we lost support for Fuji testnet of Avalanche

**What I did:** used the existing implementation in (2) and ported it in (1)