### PR TITLE
refactor: use new base Config class that allow custom networks

### DIFF
--- a/ape_avalanche/ecosystem.py
+++ b/ape_avalanche/ecosystem.py
@@ -1,9 +1,11 @@
-from typing import Optional, Type, cast
+from typing import ClassVar, cast
 
-from ape.api.config import PluginConfig
-from ape.api.networks import LOCAL_NETWORK_NAME
-from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
-from ape_ethereum.ecosystem import Ethereum, ForkedNetworkConfig, NetworkConfig
+from ape_ethereum.ecosystem import (
+    BaseEthereumConfig,
+    Ethereum,
+    NetworkConfig,
+    create_network_config,
+)
 from ape_ethereum.transactions import TransactionType
 
 NETWORKS = {
@@ -13,41 +15,9 @@ NETWORKS = {
 }
 
 
-def _create_config(
-    required_confirmations: int = 1,
-    block_time: int = 3,
-    default_provider="geth",
-    cls: Type = NetworkConfig,
-    **kwargs,
-) -> NetworkConfig:
-    return cls(
-        block_time=block_time,
-        required_confirmations=required_confirmations,
-        default_transaction_type=TransactionType.DYNAMIC,
-        default_provider=default_provider,
-        **kwargs,
-    )
-
-
-def _create_local_config(default_provider: Optional[str] = None, use_fork: bool = False, **kwargs):
-    return _create_config(
-        block_time=0,
-        default_provider=default_provider,
-        gas_limit="max",
-        required_confirmations=0,
-        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
-        cls=ForkedNetworkConfig if use_fork else NetworkConfig,
-        **kwargs,
-    )
-
-
-class AvalancheConfig(PluginConfig):
-    mainnet: NetworkConfig = _create_config()
-    mainnet_fork: ForkedNetworkConfig = _create_local_config(use_fork=True)
-    fuji: NetworkConfig = _create_config()
-    fuji_fork: ForkedNetworkConfig = _create_local_config(use_fork=True)
-    local: NetworkConfig = _create_local_config(default_provider="test")
-    default_network: str = LOCAL_NETWORK_NAME
+class AvalancheConfig(BaseEthereumConfig):
+    mainnet: NetworkConfig = create_network_config(block_time=3, required_confirmations=1)
+    fuji: NetworkConfig = create_network_config(block_time=3, required_confirmations=1)
 
 
 class Avalanche(Ethereum):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+from ape_ethereum.transactions import TransactionType
+
+from ape_avalanche.ecosystem import AvalancheConfig
+
+
+def test_gas_limit(avalanche):
+    assert avalanche.config.local.gas_limit == "max"
+
+
+def test_default_transaction_type(avalanche):
+    assert avalanche.config.mainnet.default_transaction_type == TransactionType.DYNAMIC
+
+
+def test_mainnet_fork_not_configured():
+    obj = AvalancheConfig.model_validate({})
+    assert obj.mainnet_fork.required_confirmations == 0
+
+
+def test_mainnet_fork_configured():
+    data = {"mainnet_fork": {"required_confirmations": 555}}
+    obj = AvalancheConfig.model_validate(data)
+    assert obj.mainnet_fork.required_confirmations == 555
+
+
+def test_custom_network():
+    data = {"apenet": {"required_confirmations": 333}}
+    obj = AvalancheConfig.model_validate(data)
+    assert obj.apenet.required_confirmations == 333

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -3,10 +3,6 @@ from ape_ethereum.transactions import TransactionType
 from ethpm_types import MethodABI
 
 
-def test_gas_limit(avalanche, eth_tester_provider):
-    assert avalanche.config.local.gas_limit == "max"
-
-
 # NOTE: None because we want to show the default is DYNAMIC
 @pytest.mark.parametrize("tx_type", (None, 2, "0x2"))
 def test_create_transaction(avalanche, tx_type, eth_tester_provider):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,5 @@
-def test_use_provider(accounts, networks, eth_tester_provider):
+def test_use_provider(accounts, eth_tester_provider):
+    _ = eth_tester_provider
     account = accounts.test_accounts[0]
     receipt = account.transfer(account, 100)
 


### PR DESCRIPTION
### What I did

so we can use the new custom networks, utilize the new base class

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
